### PR TITLE
New Token Type TableData with Line Numbers added

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -30,7 +30,7 @@ func NewFromFile(path string) *Lexer {
 		panic(err)
 	}
 
-	l := &Lexer{input: string(dat), FilePath: path}
+	l := &Lexer{input: string(dat), FilePath: path, currentLineNo: 1}
 	l.readChar()
 	return l
 }

--- a/object/object.go
+++ b/object/object.go
@@ -70,5 +70,27 @@ type Step struct {
 	LineNumber int
 }
 
+// TableData is a representation of a cell in a gherkin Table
+type TableData struct {
+	Literal    string
+	LineNumber int
+}
+
 // Table is a representation of any Table in Gherkin
-type Table [][]string
+type Table [][]TableData
+
+// TableFromString creates a Table type from given 2D string array
+func TableFromString(strTable [][]string, startingLine int) Table {
+	var res Table
+	var resRow []TableData
+	curLine := startingLine
+	for _, row := range strTable {
+		resRow = []TableData{}
+		for _, item := range row {
+			resRow = append(resRow, TableData{Literal: item, LineNumber: curLine})
+		}
+		res = append(res, resRow)
+		curLine++
+	}
+	return res
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -410,20 +410,20 @@ func (p *Parser) ParseStep() *object.Step {
 // ParseTable parses a Table from the current position in the parser
 func (p *Parser) ParseTable() *object.Table {
 	var table object.Table
-	var tmp []string
+	var tmp []object.TableData
 	p.skipNewLines()
 	if !p.curTokenIs(token.TABLEDATA) {
 		p.peekError(token.TABLEDATA)
 		return nil
 	}
 	for p.curTokenIs(token.TABLEDATA) {
-		tmp = []string{}
+		tmp = []object.TableData{}
 		for !(p.curTokenIs(token.NEWLINE) || p.curTokenIs(token.EOF)) {
 			if !p.curTokenIs(token.TABLEDATA) {
 				p.peekError(token.TABLEDATA)
 				return nil
 			}
-			tmp = append(tmp, p.curToken.Literal)
+			tmp = append(tmp, object.TableData{p.curToken.Literal, p.curToken.LineNumber})
 			p.nextToken()
 		}
 

--- a/reporter/report.go
+++ b/reporter/report.go
@@ -101,7 +101,7 @@ func PrintTable(out io.Writer, table object.Table) {
 		for _, row := range table {
 			io.WriteString(out, "\n\t\t\t")
 			for _, data := range row {
-				io.WriteString(out, data)
+				io.WriteString(out, data.Literal)
 				io.WriteString(out, "\t")
 			}
 		}

--- a/token/token.go
+++ b/token/token.go
@@ -70,6 +70,8 @@ func (token Type) String() string {
 		return "EOF"
 	case NEWLINE:
 		return "NEW_LINE"
+	case STEPBODY:
+		return "STEP_TEXT"
 	}
 
 	return "Illegal"


### PR DESCRIPTION
- Create New Type `TableData` representing each cell in Gherkin Table
- Change Table type from `[][]string` to `[][]TableData`
- Add necessary changes to adapt
