### PR TITLE
Add support for multiple example table with tags

### DIFF
--- a/object/object.go
+++ b/object/object.go
@@ -74,7 +74,8 @@ type ScenarioOutline struct {
 	Tags         []string
 	ScenarioText string
 	LineNumber   int
-	Table        Table
+	Tables       []Table
+	TableTags    [][]string
 }
 
 func (so *ScenarioOutline) scenarioTypeObject() {}
@@ -86,16 +87,19 @@ func (so *ScenarioOutline) GetTags() []string { return so.Tags }
 func (so *ScenarioOutline) GetScenarios() []Scenario {
 	var scenarios []Scenario
 	var steps []Step
-	for i, row := range so.Table.GetHash() {
-		line := so.Table[i+1][0].LineNumber
-		steps = []Step{}
-		for _, step := range so.Steps {
-			steps = append(steps, *step.substituteExampleTable(row))
+	for j, table := range so.Tables {
+		for i, row := range table.GetHash() {
+			line := table[i+1][0].LineNumber
+			steps = []Step{}
+			for _, step := range so.Steps {
+				steps = append(steps, *step.substituteExampleTable(row))
+			}
+			newTags := append(so.Tags, so.TableTags[j]...)
+			scenarios = append(
+				scenarios,
+				Scenario{steps, newTags, so.ScenarioText, line},
+			)
 		}
-		scenarios = append(
-			scenarios,
-			Scenario{steps, so.Tags, so.ScenarioText, line},
-		)
 	}
 	return scenarios
 }

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -271,11 +271,14 @@ func TestGetScenarios(t *testing.T) {
 		[]string{},
 		"Test Scenario",
 		1,
-		TableFromString([][]string{
-			[]string{"with", "data"},
-			[]string{"4", "5"},
-			[]string{"and", "string"},
-		}, 4),
+		[]Table{
+			TableFromString([][]string{
+				[]string{"with", "data"},
+				[]string{"4", "5"},
+				[]string{"and", "string"},
+			}, 4),
+		},
+		[][]string{{}},
 	}
 
 	expectedScenarios := []Scenario{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -330,7 +330,7 @@ func (p *Parser) ParseScenarioTypeSet() []object.ScenarioType {
 			if !ok {
 				panic("invalid type")
 			}
-			lastOutline.Tables[len(lastOutline.Tables) - 1].Append(extraTable.GetRows())
+			lastOutline.Tables[len(lastOutline.Tables)-1].Append(extraTable.GetRows())
 		}
 
 	}
@@ -379,8 +379,8 @@ func (p *Parser) ParseScenarioType(lastTags []string) object.ScenarioType {
 
 		for {
 			p.skipNewLines()
-			if (!(p.curTokenIs(token.TAG) || p.curTokenIs(token.EXAMPLES))) {
-				if (len(tables) < 1) {
+			if !(p.curTokenIs(token.TAG) || p.curTokenIs(token.EXAMPLES)) {
+				if len(tables) < 1 {
 					return nil
 				}
 				break

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -374,7 +374,7 @@ func TestParseScenarioOutlineMultipleExamples(t *testing.T) {
 	if !areArrayEqual(scenario.Tags, expectedTags) {
 		t.Fatalf("Tags mismatch, expected %v, got %v", expectedTags, scenario.Tags)
 	}
-	expectedTable := []object.Table {
+	expectedTable := []object.Table{
 		object.TableFromString([][]string{
 			{"data1", "data2"},
 			{"value1", "v1"},
@@ -391,7 +391,7 @@ func TestParseScenarioOutlineMultipleExamples(t *testing.T) {
 		}
 	}
 
-	expectedTableTags := [][]string {
+	expectedTableTags := [][]string{
 		{"tag1", "tag-hello"},
 		{"tag2", "tag-world"},
 	}
@@ -437,7 +437,7 @@ func TestParseScenarioOutlineMultipleExamples2(t *testing.T) {
 	if !areArrayEqual(scenario.Tags, expectedTags) {
 		t.Fatalf("Tags mismatch, expected %v, got %v", expectedTags, scenario.Tags)
 	}
-	expectedTable := []object.Table {
+	expectedTable := []object.Table{
 		object.TableFromString([][]string{
 			{"data1", "data2"},
 			{"value1", "v1"},
@@ -454,7 +454,7 @@ func TestParseScenarioOutlineMultipleExamples2(t *testing.T) {
 		}
 	}
 
-	expectedTableTags := [][]string {
+	expectedTableTags := [][]string{
 		{},
 		{"tag2", "tagworld"},
 	}
@@ -465,7 +465,6 @@ func TestParseScenarioOutlineMultipleExamples2(t *testing.T) {
 		}
 	}
 }
-
 
 func TestParseBackground(t *testing.T) {
 	backgrounds := []string{
@@ -609,7 +608,7 @@ func TestParseScenarioTypeSetWithOutline(t *testing.T) {
 			for i, tt := range stepDataProvider[data.dataProviderKey] {
 				assertStepsEqual(t, &scenario.Steps[i], tt)
 			}
-			expectedTable := []object.Table {
+			expectedTable := []object.Table{
 				object.TableFromString([][]string{
 					{"data"},
 					{"row"},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -334,10 +334,138 @@ func TestParseScenarioOutline(t *testing.T) {
 		[]string{"value2", "5"},
 	}, 5)
 
-	if !areTablesEqual(expectedTable, scenario.Table) {
-		t.Fatalf("Tables mismatch, expected %v, got %v", expectedTable, scenario.Table)
+	if !areTablesEqual(expectedTable, scenario.Tables[0]) {
+		t.Fatalf("Tables mismatch, expected %v, got %v", expectedTable, scenario.Tables[0])
 	}
 }
+
+func TestParseScenarioOutlineMultipleExamples(t *testing.T) {
+	input := fmt.Sprintf(`
+	Scenario Outline: test Scenario
+		%v
+
+	@tag1 @tag-hello
+	Examples:
+		| data1  | data2 |
+		| value1 | v1    |
+
+	@tag2 @tag-world
+	Examples:
+		| data1  | data2 |
+		| value2 | 5     |
+	`, stepInput1)
+	l := lexer.New(input)
+	p := New(l)
+
+	res := p.ParseScenarioType([]string{})
+	checkParserErrors(t, p)
+	scenario, ok := res.(*object.ScenarioOutline)
+	if !ok {
+		t.Fatalf("Type mismatch, expected Scenario but not got")
+	}
+	if len(scenario.Steps) != 3 {
+		t.Fatalf("Steps length mismatch, expected 3, got %v", len(scenario.Steps))
+	}
+
+	for i, tt := range stepDataProvider["data1"] {
+		assertStepsEqual(t, &scenario.Steps[i], tt)
+	}
+	expectedTags := []string{}
+	if !areArrayEqual(scenario.Tags, expectedTags) {
+		t.Fatalf("Tags mismatch, expected %v, got %v", expectedTags, scenario.Tags)
+	}
+	expectedTable := []object.Table {
+		object.TableFromString([][]string{
+			{"data1", "data2"},
+			{"value1", "v1"},
+		}, 5),
+		object.TableFromString([][]string{
+			{"data1", "data2"},
+			{"value2", "5"},
+		}, 5),
+	}
+
+	for i, table := range scenario.Tables {
+		if !areTablesEqual(expectedTable[i], table) {
+			t.Fatalf("Tables mismatch, expected %v, got %v", expectedTable[i], table)
+		}
+	}
+
+	expectedTableTags := [][]string {
+		{"tag1", "tag-hello"},
+		{"tag2", "tag-world"},
+	}
+
+	for i, table := range scenario.TableTags {
+		if !areArrayEqual(expectedTableTags[i], table) {
+			t.Fatalf("Table tags mismatch, expected %v, got %v", expectedTableTags[i], table)
+		}
+	}
+}
+
+func TestParseScenarioOutlineMultipleExamples2(t *testing.T) {
+	input := fmt.Sprintf(`
+	Scenario Outline: test Scenario
+		%v
+
+	Examples:
+		| data1  | data2 |
+		| value1 | v1    |
+
+	@tag2 @tagworld
+	Examples:
+		| data1  | data2 |
+		| value2 | 5     |
+	`, stepInput1)
+	l := lexer.New(input)
+	p := New(l)
+
+	res := p.ParseScenarioType([]string{})
+	checkParserErrors(t, p)
+	scenario, ok := res.(*object.ScenarioOutline)
+	if !ok {
+		t.Fatalf("Type mismatch, expected Scenario but not got")
+	}
+	if len(scenario.Steps) != 3 {
+		t.Fatalf("Steps length mismatch, expected 3, got %v", len(scenario.Steps))
+	}
+
+	for i, tt := range stepDataProvider["data1"] {
+		assertStepsEqual(t, &scenario.Steps[i], tt)
+	}
+	expectedTags := []string{}
+	if !areArrayEqual(scenario.Tags, expectedTags) {
+		t.Fatalf("Tags mismatch, expected %v, got %v", expectedTags, scenario.Tags)
+	}
+	expectedTable := []object.Table {
+		object.TableFromString([][]string{
+			{"data1", "data2"},
+			{"value1", "v1"},
+		}, 5),
+		object.TableFromString([][]string{
+			{"data1", "data2"},
+			{"value2", "5"},
+		}, 5),
+	}
+
+	for i, table := range scenario.Tables {
+		if !areTablesEqual(expectedTable[i], table) {
+			t.Fatalf("Tables mismatch, expected %v, got %v", expectedTable[i], table)
+		}
+	}
+
+	expectedTableTags := [][]string {
+		{},
+		{"tag2", "tagworld"},
+	}
+
+	for i, table := range scenario.TableTags {
+		if !areArrayEqual(expectedTableTags[i], table) {
+			t.Fatalf("Table tags mismatch, expected %v, got %v", expectedTableTags[i], table)
+		}
+	}
+}
+
 
 func TestParseBackground(t *testing.T) {
 	backgrounds := []string{
@@ -481,14 +609,18 @@ func TestParseScenarioTypeSetWithOutline(t *testing.T) {
 			for i, tt := range stepDataProvider[data.dataProviderKey] {
 				assertStepsEqual(t, &scenario.Steps[i], tt)
 			}
-			expectedTable := object.TableFromString([][]string{
-				[]string{"data"},
-				[]string{"row"},
-				[]string{"row1"},
-			}, 22)
+			expectedTable := []object.Table {
+				object.TableFromString([][]string{
+					{"data"},
+					{"row"},
+					{"row1"},
+				}, 22),
+			}
 
-			if !areTablesEqual(expectedTable, scenario.Table) {
-				t.Fatalf("Tables mismatch, expected %v, got %v", expectedTable, scenario.Table)
+			for i, table := range scenario.Tables {
+				if !areTablesEqual(expectedTable[i], table) {
+					t.Fatalf("Tables mismatch, expected %v, got %v", expectedTable[i], table)
+				}
 			}
 		}
 	}

--- a/reporter/report.go
+++ b/reporter/report.go
@@ -60,7 +60,7 @@ func PrintResult(out io.Writer, featureSet *object.FeatureSet) {
 				io.WriteString(out, "\n")
 				for _, s := range outlineObj.GetScenarios() {
 					steps = outlineObj.Steps
-					table = outlineObj.Table
+					tables := outlineObj.Tables
 					lineNumber = s.LineNumber
 					io.WriteString(out, "\t\tTitle: ")
 					io.WriteString(out, titleString)
@@ -75,7 +75,9 @@ func PrintResult(out io.Writer, featureSet *object.FeatureSet) {
 					io.WriteString(out, "]")
 					io.WriteString(out, "\n\t\t\t\t")
 					PrintSteps(out, steps, 4)
-					PrintTable(out, table)
+					for _, table := range tables {
+						PrintTable(out, table)
+					}
 					io.WriteString(out, "\n\t")
 				}
 			} else {


### PR DESCRIPTION
Add support for multiple tables with tags

``` gherkin
Scenario Outline: test Scenario
  Given some test step
  Then some data is 5
  But some "guy" has a table
    | with | data   |
    | 4    | 5      |
    | and  | string |`
                                 
  Examples:       
    | data1  | data2 |  
    | value1 | v1    |
                
  @tag2 @tagworld    
  Examples:     
    | data1  | data2 |
    | value2 | 5     |
```